### PR TITLE
Fix mobile home navigation overlap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,5 +19,6 @@ Next.js portfolio site using the App Router, TypeScript, Sass, and npm.
 ## Conventions
 
 - Use the existing TypeScript, App Router, and Sass patterns.
+- Next.js rewrites the tracked `next-env.d.ts` route-types import while `npm run dev` runs. Do not commit a change that only switches between `.next/types/routes.d.ts` and `.next/dev/types/routes.d.ts`.
 - Keep `README.md` current as the project evolves.
 - Update this file when project guidance or layout materially changes without bloating it.

--- a/components/Header.module.scss
+++ b/components/Header.module.scss
@@ -137,3 +137,9 @@
     color: var(--accent);
   }
 }
+
+@media (max-width: 400px) {
+  .navLink:first-child {
+    display: none;
+  }
+}


### PR DESCRIPTION
## Summary

- hide the duplicate Home navigation item on compact screens, retaining the logo link
- document Next.js development route-type rewrites to prevent accidental commits

## Verification

- `npm run lint`
- `npm run format:check`